### PR TITLE
Add script to convert md to pdf

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     name: Convert
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout this repo (plastics-interventions-doc)
+      - name: Checkout
         uses: actions/checkout@v3
       - name: Convert Markdown to PDF
         run: |
@@ -20,6 +20,11 @@ jobs:
             output_file="pdfs/$(basename $file .md).pdf"
             docker run --volume $PWD:/data pandoc/latex:2.9 --output=/data/$output_file /data/$file
           done
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: pdfs
+          path: pdfs
   upload: 
     name: Upload
     runs-on: ubuntu-latest
@@ -27,11 +32,10 @@ jobs:
     environment: deploy
     if: github.ref == 'refs/heads/main'
     steps:
-      - name: Upload GitHub artifact
-        uses: actions/upload-artifact@v3
+      - name: Download PDFs
+        uses: actions/download-artifact@v3
         with:
           name: pdfs
-          path: pdfs
       - name: Upload PDFs to tool
         uses: Creepios/sftp-action@v1.0.3
         with:


### PR DESCRIPTION
Script converts markdowns in repo to PDFs. Outputs the PDFs as GitHub workflow artifacts and to https://global-plastics-tool.org/pdf (using password-based authentication to connect to the SFTP server). 

Development notes:
- Chose to put .yaml script in this repo (`plastics-interventions-doc`) where the md files are as opposed to where the tool exists (`plastics-prototype`), as it feels cleaner. Initially coded it in the repo where the tool is (`plastics-prototype`). We can still do that if preferred and use a `repository_dispatch` triggered whenever there is a push to the `plastics-interventions-doc` repo to run the workflow in `plastics-prototype`. Let me know if there's a preference for this implementation.
-  Bash scripts included in the yaml file using `run |`. Let me know if you’d prefer me to separate the bash script I use to run the job from the yaml file. Currently put it in the yaml file because this is a small repo and bash script and it seemed more superfluous than helpful to separate.
- Developed primarily in https://github.com/SchmidtDSE/test-md-to-pdf to test directly in a Github repo workflow environment without triggering too much noise in the `plastics-prototype` and `plastics-interventions-doc` repos.
